### PR TITLE
Add control plane URL configuration

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -15,3 +15,7 @@ npm run dev
 
 By default the development server proxies API requests to `http://localhost:1234`.
 Adjust the proxy in `vite.config.ts` if your control plane runs elsewhere.
+
+You can also specify the control plane URL directly using the `VITE_CONTROL_PLANE_URL`
+environment variable. Set this when running the dev server or building the app
+to have the frontend talk to a remote control plane.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,5 @@
+import { Snops } from 'snops_sdk';
+
+const CONTROL_PLANE_URL = (import.meta.env.VITE_CONTROL_PLANE_URL as string) || '';
+
+export const api = new Snops(CONTROL_PLANE_URL);

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Snops } from 'snops_sdk';
+import { api } from '../api';
 
 interface AgentStatus {
   agent_id: string;
@@ -7,7 +7,6 @@ interface AgentStatus {
   external_ip?: string;
 }
 
-const api = new Snops('');
 
 export default function AgentsPage() {
   const [agents, setAgents] = useState<AgentStatus[]>([]);

--- a/web/src/pages/EnvsPage.tsx
+++ b/web/src/pages/EnvsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Snops } from 'snops_sdk';
+import { api } from '../api';
 
-const api = new Snops('');
 
 export default function EnvsPage() {
   const [envs, setEnvs] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- allow web frontend to specify control plane URL via environment variable
- share configured API instance across pages
- document how to override the control plane host

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c74927b48833088429b9db250acd4