### PR TITLE
Add detail pages for agents and environments

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { Link, Route, Routes } from 'react-router-dom';
 import AgentsPage from './pages/AgentsPage';
+import AgentInfoPage from './pages/AgentInfoPage';
 import EnvsPage from './pages/EnvsPage';
+import EnvInfoPage from './pages/EnvInfoPage';
 import Dashboard from './pages/Dashboard';
 
 export default function App() {
@@ -14,7 +16,9 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/agents" element={<AgentsPage />} />
+        <Route path="/agents/:agentId" element={<AgentInfoPage />} />
         <Route path="/envs" element={<EnvsPage />} />
+        <Route path="/envs/:envId" element={<EnvInfoPage />} />
       </Routes>
     </>
   );

--- a/web/src/pages/AgentInfoPage.tsx
+++ b/web/src/pages/AgentInfoPage.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../api';
+
+interface AgentStatus {
+  agent_id: string;
+  is_connected: boolean;
+  external_ip?: string;
+  internal_ip?: string;
+  state: any;
+}
+
+export default function AgentInfoPage() {
+  const { agentId } = useParams();
+  const [agent, setAgent] = useState<AgentStatus | null>(null);
+
+  useEffect(() => {
+    if (!agentId) return;
+    api.agents
+      .get(agentId)
+      .then(setAgent)
+      .catch((e) => console.error(e));
+  }, [agentId]);
+
+  if (!agent) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Agent {agent.agent_id}</h2>
+      <p>Status: {agent.is_connected ? 'online' : 'offline'}</p>
+      {agent.external_ip && <p>External IP: {agent.external_ip}</p>}
+      {agent.internal_ip && <p>Internal IP: {agent.internal_ip}</p>}
+      <pre>{JSON.stringify(agent.state, null, 2)}</pre>
+      <Link to="/agents">Back to Agents</Link>
+    </div>
+  );
+}

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { api } from '../api';
 
 interface AgentStatus {
@@ -24,8 +25,10 @@ export default function AgentsPage() {
       <ul>
         {agents.map((a) => (
           <li key={a.agent_id}>
-            {a.agent_id} - {a.is_connected ? 'online' : 'offline'}{' '}
-            {a.external_ip && `(${a.external_ip})`}
+            <Link to={`/agents/${a.agent_id}`}>
+              {a.agent_id} - {a.is_connected ? 'online' : 'offline'}{' '}
+              {a.external_ip && `(${a.external_ip})`}
+            </Link>
           </li>
         ))}
       </ul>

--- a/web/src/pages/EnvInfoPage.tsx
+++ b/web/src/pages/EnvInfoPage.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../api';
+
+export default function EnvInfoPage() {
+  const { envId } = useParams();
+  const [info, setInfo] = useState<any>(null);
+
+  useEffect(() => {
+    if (!envId) return;
+    api
+      .env(envId)
+      .info()
+      .then(setInfo)
+      .catch((e) => console.error(e));
+  }, [envId]);
+
+  if (!info) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Environment {envId}</h2>
+      <pre>{JSON.stringify(info, null, 2)}</pre>
+      <Link to="/envs">Back to Environments</Link>
+    </div>
+  );
+}

--- a/web/src/pages/EnvsPage.tsx
+++ b/web/src/pages/EnvsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { api } from '../api';
 
 
@@ -18,7 +19,9 @@ export default function EnvsPage() {
       <h2>Environments</h2>
       <ul>
         {envs.map((e) => (
-          <li key={e}>{e}</li>
+          <li key={e}>
+            <Link to={`/envs/${e}`}>{e}</Link>
+          </li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- add `AgentInfoPage` and `EnvInfoPage`
- link each agent and environment to its info page
- register new pages in router

## Testing
- `cargo test --quiet` *(fails: failed to fetch dependency)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c78a983948330aa26d0a621411115