### PR TITLE
Enhance JSON table display

### DIFF
--- a/web/src/components/JsonTable.css
+++ b/web/src/components/JsonTable.css
@@ -1,0 +1,11 @@
+.json-table {
+  border-collapse: collapse;
+  margin-bottom: 0.5rem;
+}
+
+.json-table th,
+.json-table td {
+  border: 1px solid #ccc;
+  padding: 2px 4px;
+  vertical-align: top;
+}

--- a/web/src/components/JsonTable.tsx
+++ b/web/src/components/JsonTable.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import './JsonTable.css';
+
+interface JsonTableProps {
+  data: any;
+}
+
+function renderValue(value: any): React.ReactNode {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (typeof value === 'object') {
+    if (Array.isArray(value)) {
+      return (
+        <table className="json-table">
+          <tbody>
+            {value.map((v, i) => (
+              <tr key={i}>
+                <th>{i}</th>
+                <td>{renderValue(v)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+    return (
+      <table className="json-table">
+        <tbody>
+          {Object.entries(value).map(([k, v]) => (
+            <tr key={k}>
+              <th>{k}</th>
+              <td>{renderValue(v)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  return String(value);
+}
+
+export default function JsonTable({ data }: JsonTableProps) {
+  return <>{renderValue(data)}</>;
+}

--- a/web/src/pages/AgentInfoPage.tsx
+++ b/web/src/pages/AgentInfoPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api } from '../api';
+import JsonTable from '../components/JsonTable';
 
 interface AgentStatus {
   agent_id: string;
@@ -32,7 +33,8 @@ export default function AgentInfoPage() {
       <p>Status: {agent.is_connected ? 'online' : 'offline'}</p>
       {agent.external_ip && <p>External IP: {agent.external_ip}</p>}
       {agent.internal_ip && <p>Internal IP: {agent.internal_ip}</p>}
-      <pre>{JSON.stringify(agent.state, null, 2)}</pre>
+      <h3>Agent Info</h3>
+      <JsonTable data={agent.state} />
       <Link to="/agents">Back to Agents</Link>
     </div>
   );

--- a/web/src/pages/EnvInfoPage.tsx
+++ b/web/src/pages/EnvInfoPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api } from '../api';
+import JsonTable from '../components/JsonTable';
 
 export default function EnvInfoPage() {
   const { envId } = useParams();
@@ -22,7 +23,8 @@ export default function EnvInfoPage() {
   return (
     <div>
       <h2>Environment {envId}</h2>
-      <pre>{JSON.stringify(info, null, 2)}</pre>
+      <h3>Environment Info</h3>
+      <JsonTable data={info} />
       <Link to="/envs">Back to Environments</Link>
     </div>
   );


### PR DESCRIPTION
## Summary
- style `JsonTable` tables with borders for clarity
- show only the table view on AgentInfoPage and EnvInfoPage

## Testing
- `cargo test` *(fails: could not connect to git)*

------
https://chatgpt.com/codex/tasks/task_e_683c80a3722c8330be8038275c19e21c