### PR TITLE
Add environment panel to dashboard

### DIFF
--- a/web/src/components/EnvironmentsPanel.tsx
+++ b/web/src/components/EnvironmentsPanel.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api';
+import JsonTree from './JsonTree';
+
+interface EnvData {
+  id: string;
+  network: string;
+  height: number | null;
+  online: number;
+  offline: number;
+  total: number;
+  topology: any;
+}
+
+export default function EnvironmentsPanel() {
+  const [envs, setEnvs] = useState<EnvData[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const ids = await api.env().list();
+        const data: EnvData[] = [];
+        for (const id of ids) {
+          try {
+            const [info, topology] = await Promise.all([
+              api.env(id).info(),
+              api.env(id).topology(),
+            ]);
+            const internal = (topology as any).internal || {};
+            const nodes = Object.values(internal) as any[];
+            const total = nodes.length;
+            const online = nodes.filter((n) => n.Internal?.online).length;
+            const offline = total - online;
+            data.push({
+              id,
+              network: info.network,
+              height: info.block?.height ?? null,
+              online,
+              offline,
+              total,
+              topology,
+            });
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        if (!cancelled) {
+          setEnvs(data);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div>
+      <h3>Environments</h3>
+      {envs.map((env) => (
+        <div key={env.id} style={{ marginBottom: '1rem' }}>
+          <h4>{env.id}</h4>
+          <p>Network: {env.network}</p>
+          <p>Height: {env.height ?? 'unknown'}</p>
+          <p>Agents Online: {env.online}</p>
+          <p>Agents Offline: {env.offline}</p>
+          <p>Total Agents: {env.total}</p>
+          <JsonTree data={env.topology} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/JsonTree.tsx
+++ b/web/src/components/JsonTree.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+interface TreeNodeProps {
+  label: string;
+  value: any;
+  defaultExpanded?: boolean;
+}
+
+function TreeNode({ label, value, defaultExpanded = false }: TreeNodeProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const isObject = value !== null && typeof value === 'object';
+  const toggle = () => {
+    if (isObject) {
+      setExpanded(!expanded);
+    }
+  };
+
+  return (
+    <div style={{ marginLeft: '1rem' }}>
+      <div onClick={toggle} style={{ cursor: isObject ? 'pointer' : 'default' }}>
+        {isObject ? (expanded ? '▾' : '▸') : '-'} {label}
+        {!isObject && ': '}
+        {!isObject && String(value)}
+      </div>
+      {isObject && expanded && (
+        <div>
+          {Array.isArray(value)
+            ? value.map((v, i) => (
+                <TreeNode key={i} label={String(i)} value={v} />
+              ))
+            : Object.entries(value).map(([k, v]) => (
+                <TreeNode key={k} label={k} value={v} />
+              ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function JsonTree({ data }: { data: any }) {
+  return (
+    <div>
+      <TreeNode label="root" value={data} defaultExpanded />
+    </div>
+  );
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,3 +1,10 @@
+import EnvironmentsPanel from '../components/EnvironmentsPanel';
+
 export default function Dashboard() {
-  return <h2>Welcome to snops Web</h2>;
+  return (
+    <>
+      <h2>Welcome to snops Web</h2>
+      <EnvironmentsPanel />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- show environment info with EnvironmentsPanel
- add EnvironmentsPanel to Dashboard
- display topology in an expandable tree view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c8bbe2edc8330a373cc652b8ddc58