### PR TITLE
Add ControlPlaneConsole

### DIFF
--- a/web/src/components/ControlPlaneConsole.tsx
+++ b/web/src/components/ControlPlaneConsole.tsx
@@ -1,0 +1,22 @@
+import { useControlPlane } from '../controlPlane';
+
+export default function ControlPlaneConsole() {
+  const { events } = useControlPlane();
+
+  return (
+    <div style={{ width: '100%', maxWidth: '60rem', marginTop: '1rem' }}>
+      <h3 style={{ textAlign: 'center' }}>Control Plane Events</h3>
+      <div style={{ border: '1px solid #ccc', padding: '0.5rem', maxHeight: '200px', overflowY: 'auto', fontFamily: 'monospace', fontSize: '0.9rem' }}>
+        {events.length === 0 ? (
+          <div>No events received.</div>
+        ) : (
+          events.map((e, i) => (
+            <pre key={i} style={{ margin: 0 }}>
+              {JSON.stringify(e, null, 2)}
+            </pre>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/controlPlane.tsx
+++ b/web/src/controlPlane.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const CONTROL_PLANE_URL = (import.meta.env.VITE_CONTROL_PLANE_URL as string) || '';
+
+function wsUrl(): string {
+  let base = CONTROL_PLANE_URL || window.location.origin;
+  if (base.endsWith('/')) base = base.slice(0, -1);
+  return base.replace(/^http/, 'ws') + '/api/v1/events';
+}
+
+interface ControlPlaneContextValue {
+  events: any[];
+}
+
+const ControlPlaneContext = createContext<ControlPlaneContextValue>({ events: [] });
+
+export function ControlPlaneProvider({ children }: { children: React.ReactNode }) {
+  const [events, setEvents] = useState<any[]>([]);
+
+  useEffect(() => {
+    const ws = new WebSocket(wsUrl());
+    ws.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setEvents((evts) => [...evts, data]);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    return () => {
+      ws.close();
+    };
+  }, []);
+
+  return (
+    <ControlPlaneContext.Provider value={{ events }}>
+      {children}
+    </ControlPlaneContext.Provider>
+  );
+}
+
+export function useControlPlane() {
+  return useContext(ControlPlaneContext);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './global.css';
+import { ControlPlaneProvider } from './controlPlane';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ControlPlaneProvider>
+        <App />
+      </ControlPlaneProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { api } from "../api";
+import ControlPlaneConsole from "../components/ControlPlaneConsole";
 
 interface AgentStatus {
   agent_id: string;
@@ -330,6 +331,7 @@ export default function AgentsPage() {
           ))}
         </tbody>
       </table>
+      <ControlPlaneConsole />
     </div>
   );
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://caladan:1234'
-    }
+      '/api': {
+        target: 'http://caladan:1234',
+        changeOrigin: true,
+        ws: true,
+      },
+    },
   }
 });


### PR DESCRIPTION
## Summary
- add ControlPlaneContext and provider to connect to the control-plane websocket
- add ControlPlaneConsole to render streamed events
- show the console on the Agents page
- wrap the app with the provider

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c61e34eb88330be06f771144fc847