### PR TITLE
Add PEERS metrics column

### DIFF
--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -45,7 +45,7 @@ const defaultColumns: Column[] = [
   { key: "online", label: "ONLINE", sortable: true },
   { key: "internalPeers", label: "INTERNAL PEERS", sortable: true },
   { key: "externalPeers", label: "EXTERNAL PEERS", sortable: true },
-  { key: "peers", label: "PEERS", sortable: false },
+  { key: "peers", label: "PEERS (C,V,T)", sortable: false },
 ];
 
 export default function AgentsPage() {
@@ -372,7 +372,7 @@ export default function AgentsPage() {
                   case "peers":
                     return (
                       <td key={c.key} style={{ textAlign: "center" }}>
-                        {`C: ${r.peers.clients}  V:${r.peers.validators} ∑:${r.peers.total}`}
+                        {`${r.peers.clients} ${r.peers.validators} ${r.peers.total}`}
                       </td>
                     );
                   default:

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -7,6 +7,7 @@ interface AgentStatus {
   agent_id: string;
   is_connected: boolean;
   external_ip?: string;
+  internal_ip?: string;
   state: any;
 }
 
@@ -21,6 +22,11 @@ interface AgentRow {
   online: boolean;
   internalPeers: number;
   externalPeers: number;
+  peers: {
+    clients: number;
+    validators: number;
+    total: number;
+  };
 }
 
 type ColumnKey = "select" | keyof AgentRow;
@@ -39,6 +45,7 @@ const defaultColumns: Column[] = [
   { key: "online", label: "ONLINE", sortable: true },
   { key: "internalPeers", label: "INTERNAL PEERS", sortable: true },
   { key: "externalPeers", label: "EXTERNAL PEERS", sortable: true },
+  { key: "peers", label: "PEERS", sortable: false },
 ];
 
 export default function AgentsPage() {
@@ -55,6 +62,7 @@ export default function AgentsPage() {
   const [action, setAction] = useState<string>("kill");
   const [columns, setColumns] = useState<Column[]>(defaultColumns);
   const [dragCol, setDragCol] = useState<number | null>(null);
+  const [peerMetrics, setPeerMetrics] = useState<Record<string, { clients: number; validators: number; total: number }>>({});
 
   useEffect(() => {
     async function load() {
@@ -96,6 +104,43 @@ export default function AgentsPage() {
     load();
   }, []);
 
+  useEffect(() => {
+    async function fetchPeers() {
+      const metrics: Record<string, { clients: number; validators: number; total: number }> = {};
+      await Promise.all(
+        agents.map(async (a: any) => {
+          if (!a.is_connected) return;
+          const ip = a.internal_ip;
+          const state = a.state;
+          if (!ip || !(state && state.Node)) return;
+          const [envId] = state.Node as [string, any];
+          const network = envNetworks[envId] || envId;
+          try {
+            const res = await fetch(`http://${ip}:3030/${network}/peers/all/metrics`);
+            if (!res.ok) return;
+            const peers = await res.json();
+            let clients = 0;
+            let validators = 0;
+            for (const p of peers) {
+              if (Array.isArray(p) && p.length >= 2) {
+                if (p[1] === "Client") clients += 1;
+                if (p[1] === "Validator") validators += 1;
+              }
+            }
+            metrics[a.agent_id] = { clients, validators, total: clients + validators };
+          } catch (e) {
+            console.error(e);
+          }
+        })
+      );
+      setPeerMetrics(metrics);
+    }
+
+    if (agents.length > 0) {
+      fetchPeers();
+    }
+  }, [agents, envNetworks]);
+
   const rows: AgentRow[] = agents.map((a: any) => {
     let network = "";
     let nodeKey = "";
@@ -126,6 +171,7 @@ export default function AgentsPage() {
       online,
       internalPeers,
       externalPeers,
+      peers: peerMetrics[a.agent_id] || { clients: 0, validators: 0, total: 0 },
     };
   });
 
@@ -253,7 +299,8 @@ export default function AgentsPage() {
                   c.key === "network" ||
                   c.key === "online" ||
                   c.key === "internalPeers" ||
-                  c.key === "externalPeers"
+                  c.key === "externalPeers" ||
+                  c.key === "peers"
                     ? { textAlign: "center" }
                     : undefined
                 }
@@ -321,6 +368,12 @@ export default function AgentsPage() {
                     return (
                       <td key={c.key} style={{ textAlign: "center" }}>
                         {r.externalPeers}
+                      </td>
+                    );
+                  case "peers":
+                    return (
+                      <td key={c.key} style={{ textAlign: "center", whiteSpace: "pre" }}>
+                        {`Clients: ${r.peers.clients}\nValidators: ${r.peers.validators}\nTotal: ${r.peers.total}`}
                       </td>
                     );
                   default:


### PR DESCRIPTION
## Summary
- display count of node types (Clients, Validators) in new "PEERS" column
- fetch metrics from each online agent via REST API

## Testing
- `cargo test --workspace` *(fails: failed to fetch dependency due to network restrictions)*
- `npx tsc -p web/tsconfig.json` *(fails: composite setting missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c890bc7048330bc2c2168dde87ddd